### PR TITLE
Added profile and region params

### DIFF
--- a/lambda_cost_calculator.py
+++ b/lambda_cost_calculator.py
@@ -46,6 +46,9 @@ def init_boto_client(client_name, region, args):
             aws_secret_access_key=args.token_secret,
             region_name=region
         )
+    elif args.profile:
+        session = Session(profile_name=args.profile, region_name=region)
+        boto_client = session.client(client_name, region_name=region)
     else:
         boto_client = boto3.client(client_name, region_name=region)
 
@@ -223,6 +226,14 @@ if __name__ == '__main__':
             'as well (default: from local configuration.'
         ),
         metavar='token-secret'
+    )
+    parser.add_argument(
+        '--profile',
+        type=str,
+        help=(
+            'AWS profile name (default: "default").'
+        ),
+        metavar='profile'
     )
 
     arguments = parser.parse_args()

--- a/lambda_cost_calculator.py
+++ b/lambda_cost_calculator.py
@@ -119,7 +119,7 @@ def print_lambda_cost(args):
     :param args: script arguments.
     :return: None.
     """
-    regions = list_available_lambda_regions()
+    regions = args.regions.split(",") if args.regions else list_available_lambda_regions()
     progress_bar = progressbar.ProgressBar(max_value=len(regions))
     lambdas_data = []
     total_monthly_cost = 0
@@ -234,6 +234,14 @@ if __name__ == '__main__':
             'AWS profile name (default: "default").'
         ),
         metavar='profile'
+    )
+    parser.add_argument(
+        '--regions',
+        type=str,
+        help=(
+            'Comma separated list of AWS regions to process (default: all regions).'
+        ),
+        metavar='regions'
     )
 
     arguments = parser.parse_args()


### PR DESCRIPTION
This pull request adds --profile and --regions arguments.

The --profile argument allows the script to be run using an AWS profile name instead of specifying the access and secret keys on the command line. It also makes it possible to use credentials with a session token (for example, those generate via AWS SSO).

The --region argument reduces the time taken to run the script when the regions in which functions exist is known.